### PR TITLE
fixing the class name on schedule card

### DIFF
--- a/lib/widgets/schedule_card.dart
+++ b/lib/widgets/schedule_card.dart
@@ -50,7 +50,7 @@ class ScheduleCard extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.end,
                   children: <Widget>[
                     Text(
-                      className,
+                      className.length > 14 ? className.substring(0,10) + '...' : className,
                       style:TextStyle(
                             color: color,
                             fontSize: 25,


### PR DESCRIPTION
When the class name is up to 10 characters trow an error. Now work correctly.